### PR TITLE
Add loader visibility test with Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# OGCAO WebSite
+
+This repository contains a simple static website. A Jest-based test suite is provided to verify the behaviour of the loader animation.
+
+## Setup
+
+```bash
+npm install
+```
+
+## Running tests
+
+```bash
+npm test
+```
+
+This will execute the test located in `tests/loader.test.js` which ensures that the `#loader` element receives the `hidden` class after one second when the page loads.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ogcao-website",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0",
+    "jquery": "^3.7.1"
+  }
+}

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+const vm = require('vm');
+
+test('loader element gains hidden class after 1 second', () => {
+  jest.useFakeTimers();
+
+  const html = fs.readFileSync(path.join(__dirname, '..', 'Index.html'), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'dangerously' });
+  const { window } = dom;
+
+  const $ = require('jquery')(window);
+  window.jQuery = window.$ = $;
+  $.fn.owlCarousel = function() { return this; };
+
+  global.window = window;
+  global.document = window.document;
+
+  const scriptContent = fs.readFileSync(path.join(__dirname, '..', 'script.js'), 'utf8');
+  vm.runInContext(scriptContent, dom.getInternalVMContext());
+
+  window.dispatchEvent(new window.Event('load'));
+  jest.advanceTimersByTime(1100);
+
+  expect(window.document.getElementById('loader').classList.contains('hidden')).toBe(true);
+});


### PR DESCRIPTION
## Summary
- set up jest, jsdom and jquery
- add a test checking that `#loader` gets the `hidden` class after 1s
- document how to run the tests

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e932300c832cbccb51bf481ff451